### PR TITLE
Update package.json to point to the proper main script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pir",
   "version": "0.0.5",
   "description": "Node library for PIR motion detector",
-  "main": "examples/pir.js",
+  "main": "",
   "scripts": {
     "test": "tessel run test/*.js"
   },


### PR DESCRIPTION
Since the module exporting the default index.js no main is required.
This commit ensures that require works.

``` javascript
var pir = require('pir'); 
```
